### PR TITLE
Throttling test

### DIFF
--- a/throttle_test.go
+++ b/throttle_test.go
@@ -42,16 +42,32 @@ func TestThrottleLow(t *testing.T) {
 	th := NewThrottler(100, 1*time.Second)
 	start := time.Now()
 	for i := 0; i < 200; i++ {
-		LogThrottle(WARN, 100, "throttle", "hihi %v", i)
+		LogThrottleKey(WARN, 100, "throttle", "hello %v", i)
+		//LogThrottle(WARN, 100, "throttle", "hihi %v", i)
 		if th.Throttle() {
 			throttled++
 		}
 	}
-	Infof("Time taken Low: %v\n\n", time.Since(start))
+	Infof("\n\nTime taken Low: %v\n", time.Since(start))
 	assert.Tf(t, throttled == 100, "Should throttle 100 of 200 requests: %v", throttled)
 }
 
 func TestThrottleMed(t *testing.T) {
+	throttled := 0
+	th := NewThrottler(1000, 1*time.Second)
+	start := time.Now()
+	for i := 0; i < 2000; i++ {
+		LogThrottleKey(WARN, 1000, "throttle", "hello %v", i)
+		//LogThrottle(WARN, 1000, "throttle", "hihi %v", i)
+		if th.Throttle() {
+			throttled++
+		}
+	}
+	Infof("\n\nTime taken Med: %v\n", time.Since(start))
+	assert.Tf(t, throttled == 1000, "Should throttle 1000 of 2000 requests: %v", throttled)
+}
+
+func TestThrottleMed5(t *testing.T) {
 	throttled := 0
 	th := NewThrottler(1000, 1*time.Second)
 	start := time.Now()
@@ -61,8 +77,8 @@ func TestThrottleMed(t *testing.T) {
 			throttled++
 		}
 	}
-	Infof("Time taken Med: %v\n\n", time.Since(start))
-	assert.Tf(t, throttled == 1000, "Should throttle 1000 of 2000 requests: %v", throttled)
+	Infof("\n\nTime taken Med5: %v\n", time.Since(start))
+	assert.Tf(t, throttled == 5000, "Should throttle 5000 of 10000 requests: %v", throttled)
 }
 
 func TestThrottleBig(t *testing.T) {
@@ -75,7 +91,7 @@ func TestThrottleBig(t *testing.T) {
 			throttled++
 		}
 	}
-	Infof("Time taken Big: %v\n\n", time.Since(start))
+	Infof("\n\nTime taken Big: %v\n", time.Since(start))
 	assert.Tf(t, throttled == 10000, "Should throttle 10000 of 20000 requests: %v", throttled)
 }
 
@@ -89,7 +105,7 @@ func TestThrottleBigger(t *testing.T) {
 			throttled++
 		}
 	}
-	Infof("Time taken: %v\n\n", time.Since(start))
+	Infof("\n\nTime taken: %v\n", time.Since(start))
 	assert.Tf(t, throttled == 100000, "Should throttle 100000 of 200000 requests: %v", throttled)
 }
 
@@ -104,6 +120,6 @@ func TestThrottleAbsurd(t *testing.T) {
 			throttled++
 		}
 	}
-	Infof("Time taken: %v\n\n", time.Since(start))
+	Infof("\n\nTime taken absurd: %v\n", time.Since(start))
 	assert.Tf(t, throttled == 1000000, "Should throttle 1000000 of 2000000 requests, but seems to break limiting algorithm: %v", throttled)
 }

--- a/throttle_test.go
+++ b/throttle_test.go
@@ -27,7 +27,7 @@ func TestThrottleer(t *testing.T) {
 
 func TestThrottle(t *testing.T) {
 	throttled := 0
-	th := NewThrottler(10, 1)
+	th := NewThrottler(10, 1*time.Second)
 	for i := 0; i < 20; i++ {
 		LogThrottle(WARN, 10, "throttle", "hihi %v", i)
 		if th.Throttle() {
@@ -39,7 +39,7 @@ func TestThrottle(t *testing.T) {
 
 func TestThrottleLow(t *testing.T) {
 	throttled := 0
-	th := NewThrottler(100, 1)
+	th := NewThrottler(100, 1*time.Second)
 	start := time.Now()
 	for i := 0; i < 200; i++ {
 		LogThrottle(WARN, 100, "throttle", "hihi %v", i)
@@ -53,7 +53,7 @@ func TestThrottleLow(t *testing.T) {
 
 func TestThrottleMed(t *testing.T) {
 	throttled := 0
-	th := NewThrottler(1000, 1)
+	th := NewThrottler(1000, 1*time.Second)
 	start := time.Now()
 	for i := 0; i < 2000; i++ {
 		LogThrottle(WARN, 1000, "throttle", "hihi %v", i)
@@ -68,7 +68,7 @@ func TestThrottleMed(t *testing.T) {
 func TestThrottleBig(t *testing.T) {
 	throttled := 0
 	start := time.Now()
-	th := NewThrottler(10000, 1)
+	th := NewThrottler(10000, 1*time.Second)
 	for i := 0; i < 20000; i++ {
 		LogThrottle(WARN, 10000, "throttle", "hihi %v", i)
 		if th.Throttle() {
@@ -81,7 +81,7 @@ func TestThrottleBig(t *testing.T) {
 
 func TestThrottleBigger(t *testing.T) {
 	throttled := 0
-	th := NewThrottler(100000, 1)
+	th := NewThrottler(100000, 1*time.Second)
 	start := time.Now()
 	for i := 0; i < 200000; i++ {
 		LogThrottle(WARN, 100000, "throttle", "hihi %v", i)
@@ -96,7 +96,7 @@ func TestThrottleBigger(t *testing.T) {
 func TestThrottleAbsurd(t *testing.T) {
 	throttled := 0
 	start := time.Now()
-	th := NewThrottler(1000000, 1)
+	th := NewThrottler(1000000, 1*time.Second)
 	for i := 0; i < 2000000; i++ {
 		LogThrottle(WARN, 1000000, "throttle", "hihihihi %v", i)
 		//fmt.Printf("Wat: %v\n", throttled)

--- a/throttle_test.go
+++ b/throttle_test.go
@@ -24,3 +24,86 @@ func TestThrottleer(t *testing.T) {
 	}
 	assert.Tf(t, throttled == 10, "Should throttle 10 of 20 requests: %v", throttled)
 }
+
+func TestThrottle(t *testing.T) {
+	throttled := 0
+	th := NewThrottler(10, 1)
+	for i := 0; i < 20; i++ {
+		LogThrottle(WARN, 10, "throttle", "hihi %v", i)
+		if th.Throttle() {
+			throttled++
+		}
+	}
+	assert.Tf(t, throttled == 10, "Should throttle 10 of 20 requests: %v", throttled)
+}
+
+func TestThrottleLow(t *testing.T) {
+	throttled := 0
+	th := NewThrottler(100, 1)
+	start := time.Now()
+	for i := 0; i < 200; i++ {
+		LogThrottle(WARN, 100, "throttle", "hihi %v", i)
+		if th.Throttle() {
+			throttled++
+		}
+	}
+	Infof("Time taken Low: %v\n\n", time.Since(start))
+	assert.Tf(t, throttled == 100, "Should throttle 100 of 200 requests: %v", throttled)
+}
+
+func TestThrottleMed(t *testing.T) {
+	throttled := 0
+	th := NewThrottler(1000, 1)
+	start := time.Now()
+	for i := 0; i < 2000; i++ {
+		LogThrottle(WARN, 1000, "throttle", "hihi %v", i)
+		if th.Throttle() {
+			throttled++
+		}
+	}
+	Infof("Time taken Med: %v\n\n", time.Since(start))
+	assert.Tf(t, throttled == 1000, "Should throttle 1000 of 2000 requests: %v", throttled)
+}
+
+func TestThrottleBig(t *testing.T) {
+	throttled := 0
+	start := time.Now()
+	th := NewThrottler(10000, 1)
+	for i := 0; i < 20000; i++ {
+		LogThrottle(WARN, 10000, "throttle", "hihi %v", i)
+		if th.Throttle() {
+			throttled++
+		}
+	}
+	Infof("Time taken Big: %v\n\n", time.Since(start))
+	assert.Tf(t, throttled == 10000, "Should throttle 10000 of 20000 requests: %v", throttled)
+}
+
+func TestThrottleBigger(t *testing.T) {
+	throttled := 0
+	th := NewThrottler(100000, 1)
+	start := time.Now()
+	for i := 0; i < 200000; i++ {
+		LogThrottle(WARN, 100000, "throttle", "hihi %v", i)
+		if th.Throttle() {
+			throttled++
+		}
+	}
+	Infof("Time taken: %v\n\n", time.Since(start))
+	assert.Tf(t, throttled == 100000, "Should throttle 100000 of 200000 requests: %v", throttled)
+}
+
+func TestThrottleAbsurd(t *testing.T) {
+	throttled := 0
+	start := time.Now()
+	th := NewThrottler(1000000, 1)
+	for i := 0; i < 2000000; i++ {
+		LogThrottle(WARN, 1000000, "throttle", "hihihihi %v", i)
+		//fmt.Printf("Wat: %v\n", throttled)
+		if th.Throttle() {
+			throttled++
+		}
+	}
+	Infof("Time taken: %v\n\n", time.Since(start))
+	assert.Tf(t, throttled == 1000000, "Should throttle 1000000 of 2000000 requests, but seems to break limiting algorithm: %v", throttled)
+}


### PR DESCRIPTION
Some spammy(Infof's should be removed) tests which I created with higher messages per duration settings. 

Previously there were greater divides between expected messages sent vs throtteld even the low/med tests were breaking. Things looking decent except in the absurd number of messages range.

I'm stil a little confused on how the new struct gets configured with the NewThrottling method, but this is a good step in the right direction.

```
11:22:53 throttle_test.go:55: [INFO] 

Time taken Low: 191.384µs
11:22:53 throttle_test.go:70: [INFO] 

Time taken Med: 370.076µs
11:22:53 throttle_test.go:84: [INFO] 

Time taken Med5: 448.041µs
--- FAIL: TestThrottleMed5 (0.00s)
	assert.go:15: /home/josh/go/root/src/github.com/araddon/gou/throttle_test.go:85
	assert.go:36: !  Failure
	assert.go:38: !  - Should throttle 5000 of 10000 requests: 1000
11:22:53 throttle_test.go:98: [INFO] 

Time taken Big: 5.221796ms
--- FAIL: TestThrottleBig (0.01s)
	assert.go:15: /home/josh/go/root/src/github.com/araddon/gou/throttle_test.go:99
	assert.go:36: !  Failure
	assert.go:38: !  - Should throttle 10000 of 20000 requests: 9948
11:22:53 throttle_test.go:112: [INFO] 

Time taken: 49.735997ms
--- FAIL: TestThrottleBigger (0.05s)
	assert.go:15: /home/josh/go/root/src/github.com/araddon/gou/throttle_test.go:113
	assert.go:36: !  Failure
	assert.go:38: !  - Should throttle 100000 of 200000 requests: 95027
11:22:54 throttle_test.go:127: [INFO] 

Time taken absurd: 498.38368ms
--- FAIL: TestThrottleAbsurd (0.50s)
	assert.go:15: /home/josh/go/root/src/github.com/araddon/gou/throttle_test.go:128
	assert.go:36: !  Failure
	assert.go:38: !  - Should throttle 1000000 of 2000000 requests, but seems to break limiting algorithm: 501618
11:22:54 uid_test.go:9: [DEBUG] 327230693338121729
11:22:54 uid_test.go:10: [DEBUG] 327230693338121730
FAIL
exit status 1
FAIL	github.com/araddon/gou	1.659s
```