### PR TITLE
Escape newlines

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,7 +1,6 @@
 package gou
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"os"
@@ -9,8 +8,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/mattbaird/elastigo/lib"
 )
 
 const (
@@ -60,14 +57,11 @@ var (
 		INFO:  "[INFO] ",
 		DEBUG: "[DEBUG] ",
 	}
-	escapeNewlines                = bool
+	escapeNewlines bool           = true
 	postFix                       = "" //\033[0m
 	LogLevelWords  map[string]int = map[string]int{"fatal": 0, "error": 1, "warn": 2, "info": 3, "debug": 4, "none": -1}
 	logThrottles                  = make(map[string]*Throttler)
 	throttleMu     sync.Mutex
-
-	indexer *elastigo.BulkIndexer
-	econn   *elastigo.Conn
 )
 
 // Setup default logging to Stderr, equivalent to:
@@ -82,19 +76,6 @@ func SetupLogging(lvl string) {
 //	gou.SetLogger(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile|log.Lmicroseconds), level)
 func SetupLoggingLong(lvl string) {
 	SetLogger(log.New(os.Stderr, "", log.LstdFlags|log.Llongfile|log.Lmicroseconds), strings.ToLower(lvl))
-}
-
-func SetupLoggingDestinations(hosts []string) {
-	elastigoConn = elastigo.NewConn()
-	esHost := strings.Replace(hosts, ":9200", "", -1)
-	elastigoConn.SetHosts([]string{esHost})
-	indexer := elastigoConn.NewBulkIndexerErrors(5, 120)
-	indexer.Sender = func(buf *bytes.Buffer) error {
-		log.Infof("es writing: %d bytes", buf.Len())
-		return indexer.Send(buf)
-	}
-	indexer.Start()
-	econn = elastigoConn
 }
 
 // Setup colorized output if this is a terminal
@@ -347,14 +328,6 @@ func DoLog(depth, logLvl int, msg string) {
 		loggerErr.Output(depth, LogPrefix[logLvl]+msg+postFix)
 	} else if LogLevel >= logLvl && logger != nil {
 		logger.Output(depth, LogPrefix[logLvl]+msg+postFix)
-	} else if LogLevel >= logLvl && logger != nil || loggerErr != nil {
-		if logger != nil {
-			//(index string, _type string, id, ttl string, date *time.Time, data interface{}, refresh bool)
-
-			now := time.Now()
-			idx := "logstash-" + now.Format("2006.01.02")
-			indexer.Index(idx, "golog", "hihid", "30d", now, LogPrefix[logLvl]+msg+postFix, nil)
-		}
 	}
 }
 

--- a/log.go
+++ b/log.go
@@ -94,7 +94,7 @@ func SetColorOutput() {
 }
 
 //Set whether to escape newline characters in log messages
-func EscapeNewlines(en bool) {
+func SetEscapeNewlines(en bool) {
 	escapeNewlines = en
 }
 

--- a/log.go
+++ b/log.go
@@ -57,7 +57,7 @@ var (
 		INFO:  "[INFO] ",
 		DEBUG: "[DEBUG] ",
 	}
-	escapeNewlines bool           = true
+	escapeNewlines bool           = false
 	postFix                       = "" //\033[0m
 	LogLevelWords  map[string]int = map[string]int{"fatal": 0, "error": 1, "warn": 2, "info": 3, "debug": 4, "none": -1}
 	logThrottles                  = make(map[string]*Throttler)
@@ -91,6 +91,11 @@ func SetColorOutput() {
 		LogPrefix[lvl] = color
 	}
 	postFix = "\033[0m"
+}
+
+//Set whether to escape newline characters in log messages
+func EscapeNewlines(en bool) {
+	escapeNewlines = en
 }
 
 // Setup default log output to go to a dev/null


### PR DESCRIPTION
Docker separates the process's logs by every newline. This causes issues when using services like [Logspout](https://github.com/gliderlabs/logspout) to read multi-line log messages because they're split apart. Indexers like kibana won't be able to effectively search for terms if they're split across messages.

This PR creates the option of escaping all newline characters so that multi-line log messages written on a single line. It will require a modification like [logspoutloges](https://github.com/lytics/LogspoutLoges) to un-escape the newlines before shipping to ES/kibana and return messages their original state. 

By default log messages do not have their newlines escaped, to enable the functionality  `gou.SetEscapeNewlines(true)` must be called.