### PR TITLE
gou logger now counts the number of throttled log messages for a log key

### DIFF
--- a/log.go
+++ b/log.go
@@ -283,7 +283,7 @@ func LogThrottleKey(logLvl, limit int, key, format string, v ...interface{}) {
 		throttleMu.Unlock()
 
 		if throttleCount > 0 {
-			format = fmt.Sprintf("LogsThrottled[%d] %s", throttleCount, format)
+			format = fmt.Sprintf("%s LogsThrottled[%d]", format, throttleCount)
 		}
 		DoLog(3, logLvl, fmt.Sprintf(format, v...))
 	}
@@ -311,7 +311,7 @@ func LogThrottle(logLvl, limit int, format string, v ...interface{}) {
 		throttleMu.Unlock()
 
 		if throttleCount > 0 {
-			format = fmt.Sprintf("LogsThrottled[%d] %s", throttleCount, format)
+			format = fmt.Sprintf("%s LogsThrottled[%d]", format, throttleCount)
 		}
 		DoLog(3, logLvl, fmt.Sprintf(format, v...))
 	}

--- a/log.go
+++ b/log.go
@@ -275,11 +275,16 @@ func LogThrottleKey(logLvl, limit int, key, format string, v ...interface{}) {
 			th = NewThrottler(limit, 3600*time.Second)
 			logThrottles[key] = th
 		}
-		if th.Throttle() {
+		skip, throttleCount := th.Throttle()
+		if skip {
 			throttleMu.Unlock()
 			return
 		}
 		throttleMu.Unlock()
+
+		if throttleCount > 0 {
+			format = fmt.Sprintf("LogsThrottled[%d] %s", throttleCount, format)
+		}
 		DoLog(3, logLvl, fmt.Sprintf(format, v...))
 	}
 }
@@ -297,11 +302,17 @@ func LogThrottle(logLvl, limit int, format string, v ...interface{}) {
 			th = NewThrottler(limit, 3600*time.Second)
 			logThrottles[format] = th
 		}
-		if th.Throttle() {
+		var throttleCount int32
+		skip, throttleCount := th.Throttle()
+		if skip {
 			throttleMu.Unlock()
 			return
 		}
 		throttleMu.Unlock()
+
+		if throttleCount > 0 {
+			format = fmt.Sprintf("LogsThrottled[%d] %s", throttleCount, format)
+		}
 		DoLog(3, logLvl, fmt.Sprintf(format, v...))
 	}
 }
@@ -319,11 +330,14 @@ func LogThrottleD(depth, logLvl, limit int, format string, v ...interface{}) {
 			th = NewThrottler(limit, 3600*time.Second)
 			logThrottles[format] = th
 		}
-		if th.Throttle() {
+		skip, throttleCount := th.Throttle()
+		if skip {
 			throttleMu.Unlock()
 			return
 		}
 		throttleMu.Unlock()
+
+		format = fmt.Sprintf("Log Throttled[%d] %s", throttleCount, format)
 		DoLog(depth, logLvl, fmt.Sprintf(format, v...))
 	}
 }

--- a/throttle_test.go
+++ b/throttle_test.go
@@ -10,21 +10,63 @@ import (
 func TestThrottleer(t *testing.T) {
 	th := NewThrottler(10, 10*time.Second)
 	for i := 0; i < 10; i++ {
-		assert.Tf(t, th.Throttle() == false, "Should not throttle %v", i)
+		thb, tc := th.Throttle()
+		assert.Tf(t, thb == false, "Should not throttle %v", i)
+		assert.Tf(t, tc < 10, "Throttle count should remain below 10 %v", tc)
 		time.Sleep(time.Millisecond * 10)
 	}
+
 	throttled := 0
 	th = NewThrottler(10, 1*time.Second)
 	// We are going to loop 20 times, first 10 should make it, next 10 throttled
 	for i := 0; i < 20; i++ {
 		LogThrottleKey(WARN, 10, "throttle", "hello %v", i)
-		if th.Throttle() {
+		thb, tc := th.Throttle()
+
+		if thb {
 			throttled += 1
+			assert.Tf(t, int(tc) == i-9, "Throttle count should rise %v, i: %d", tc, i)
 		}
 	}
 	assert.Tf(t, throttled == 10, "Should throttle 10 of 20 requests: %v", throttled)
+
+	// Now sleep for 1 second so that we should
+	// no longer be throttled
+	time.Sleep(time.Second * 2)
+	thb, _ := th.Throttle()
+	assert.Tf(t, thb == false, "We should not have been throttled")
+}
+
+func TestThrottler2(t *testing.T) {
+
+	th := NewThrottler(10, 1*time.Second)
+
+	tkey := "throttle2"
+	throttleMu.Lock()
+	logThrottles[tkey] = th
+	throttleMu.Unlock()
+
+	th, ok := logThrottles[tkey]
+	if !ok {
+		t.Errorf("Throttle key %s not created!", tkey)
+	}
+
+	// We are going to loop 20 times, first 10 should make it, next 10 throttled
+	for i := 0; i < 20; i++ {
+
+		LogThrottleKey(WARN, 10, tkey, "hello %v", i)
+
+	}
+
+	throttleMu.Lock()
+	th = logThrottles[tkey]
+	tcount := th.ThrottleCount()
+	assert.Tf(t, tcount == 10, "Should throttle 10 of 20 requests: %v", tcount)
+	throttleMu.Unlock()
+
 	// Now sleep for 1 second so that we should
 	// no longer be throttled
 	time.Sleep(time.Second * 1)
-	assert.Tf(t, th.Throttle() == false, "We should not have been throttled")
+	LogThrottleKey(WARN, 10, tkey, "hello again %v", 20)
+
 }


### PR DESCRIPTION
The throttled count is stored on the Throttle struct which is associated
via the global log throttle map. When the throttled messages are allowed
to log the count of messages which were hidden is prefixed to the
message.

~~`TestThrottler2` showcases the throttled logging output~~:
```
=== RUN   TestThrottler2
2016/02/25 17:53:48.158830 throttle_test.go:57: hello 0
2016/02/25 17:53:48.158842 throttle_test.go:57: hello 1
2016/02/25 17:53:48.158846 throttle_test.go:57: hello 2
2016/02/25 17:53:48.158850 throttle_test.go:57: hello 3
2016/02/25 17:53:48.158854 throttle_test.go:57: hello 4
2016/02/25 17:53:48.158857 throttle_test.go:57: hello 5
2016/02/25 17:53:48.158861 throttle_test.go:57: hello 6
2016/02/25 17:53:48.158865 throttle_test.go:57: hello 7
2016/02/25 17:53:48.158869 throttle_test.go:57: hello 8
2016/02/25 17:53:48.158873 throttle_test.go:57: hello 9
2016/02/25 17:53:49.159057 throttle_test.go:70: LogsThrottled[10] hello again 20
--- PASS: TestThrottler2 (1.00s)
```

### Updated output

Writes the throttle count as a suffix to the actual log message:
```
....
2016/02/26 09:41:26.099859 throttle_test.go:57: hello 8
2016/02/26 09:41:26.099863 throttle_test.go:57: hello 9
2016/02/26 09:41:27.099998 throttle_test.go:70: hello again 20 LogsThrottled[10]
--- PASS: TestThrottler2 (1.00s)
```

First then logs are written normally, once the throttle is breached the next log message displays the count of messages which were throttled.

