### PR TITLE
Logrus Formatter

### DIFF
--- a/log.go
+++ b/log.go
@@ -87,7 +87,7 @@ func SetupLoggingFile(f *os.File, lvl string) {
 }
 
 // SetupLogrus initializes an internal logrus.Logger object
-// which will be used for formatting JSON log messages
+// with the GCP log format compatible SeverityFormatter.
 func SetupLogrus(lvl string) {
 	loglvl, err := logrus.ParseLevel(lvl)
 	if err != nil {
@@ -96,23 +96,7 @@ func SetupLogrus(lvl string) {
 
 	rus = &logrus.Logger{
 		Out:       os.Stdout,
-		Formatter: new(logrus.JSONFormatter),
-		Hooks:     make(logrus.LevelHooks),
-		Level:     loglvl,
-	}
-}
-
-// SetupLogrusSeverityFormatter initializes an internal logrus.Logger object
-// with the GCP log format compatible SeverityFormatter.
-func SetupLogrusSeverityFormatter(lvl string) {
-	loglvl, err := logrus.ParseLevel(lvl)
-	if err != nil {
-		fmt.Printf("error parsing log level: %v", err)
-	}
-
-	rus = &logrus.Logger{
-		Out:       os.Stdout,
-		Formatter: new(logrus.SeverityFormatter), //Pass via interface?
+		Formatter: new(logrus.SeverityFormatter), //Possible to pass via interface?
 		Hooks:     make(logrus.LevelHooks),
 		Level:     loglvl,
 	}

--- a/log.go
+++ b/log.go
@@ -95,6 +95,20 @@ func SetupLogrus(lvl string) {
 	}
 }
 
+func SetupLogrusSeverityFormatter(lvl string) {
+	loglvl, err := logrus.ParseLevel(lvl)
+	if err != nil {
+		fmt.Printf("error parsing log level: %v", err)
+	}
+
+	rus = &logrus.Logger{
+		Out:       os.Stdout,
+		Formatter: new(logrus.SeverityFormatter), //Pass via interface?
+		Hooks:     make(logrus.LevelHooks),
+		Level:     loglvl,
+	}
+}
+
 func GetRus() *logrus.Logger {
 	return rus
 }

--- a/log.go
+++ b/log.go
@@ -81,10 +81,13 @@ func SetupLoggingLong(lvl string) {
 	SetLogger(log.New(os.Stderr, "", log.LstdFlags|log.Llongfile|log.Lmicroseconds), strings.ToLower(lvl))
 }
 
+// SetupLoggingFile writes logs to the file object parameter.
 func SetupLoggingFile(f *os.File, lvl string) {
-	SetLogger(log.New(f, "", log.LstdFlags|log.Llongfile|log.Lmicroseconds), strings.ToLower(lvl))
+	SetLogger(log.New(f, "", log.LstdFlags|log.Lshortfile|log.Lmicroseconds), strings.ToLower(lvl))
 }
 
+// SetupLogrus initializes an internal logrus.Logger object
+// which will be used for formatting JSON log messages
 func SetupLogrus(lvl string) {
 	loglvl, err := logrus.ParseLevel(lvl)
 	if err != nil {
@@ -99,6 +102,8 @@ func SetupLogrus(lvl string) {
 	}
 }
 
+// SetupLogrusSeverityFormatter initializes an internal logrus.Logger object
+// with the GCP log format compatible SeverityFormatter.
 func SetupLogrusSeverityFormatter(lvl string) {
 	loglvl, err := logrus.ParseLevel(lvl)
 	if err != nil {
@@ -113,6 +118,7 @@ func SetupLogrusSeverityFormatter(lvl string) {
 	}
 }
 
+// GetRus returns the logrus logger if initialized
 func GetRus() *logrus.Logger {
 	return rus
 }

--- a/log.go
+++ b/log.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/lytics/logrus"
 )
 
 const (

--- a/log.go
+++ b/log.go
@@ -81,6 +81,10 @@ func SetupLoggingLong(lvl string) {
 	SetLogger(log.New(os.Stderr, "", log.LstdFlags|log.Llongfile|log.Lmicroseconds), strings.ToLower(lvl))
 }
 
+func SetupLoggingFile(f *os.File, lvl string) {
+	SetLogger(log.New(f, "", log.LstdFlags|log.Llongfile|log.Lmicroseconds), strings.ToLower(lvl))
+}
+
 func SetupLogrus(lvl string) {
 	loglvl, err := logrus.ParseLevel(lvl)
 	if err != nil {

--- a/log_test.go
+++ b/log_test.go
@@ -15,7 +15,7 @@ func TestSetupLogToFile(t *testing.T) {
 	}
 	defer os.Remove(tmpf.Name())
 
-	//SetupLoggingFile(tmpf, "debug")
+	SetupLoggingFile(tmpf, "debug")
 	logStr := "hihi"
 	Infof(logStr)
 

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,51 @@
+package gou
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSetupLogToFile(t *testing.T) {
+	tmpf, err := ioutil.TempFile("", "goutest")
+	if err != nil {
+		t.Fatalf("error creating log file: %v\n", err)
+	}
+	defer os.Remove(tmpf.Name())
+
+	//SetupLoggingFile(tmpf, "debug")
+	logStr := "hihi"
+	Infof(logStr)
+
+	// Flush file buffer to disk
+	err = tmpf.Sync()
+	if err != nil {
+		t.Errorf("error syncing tmpf: %v", err)
+	}
+	time.Sleep(1 * time.Second)
+
+	// Read tmp file and confirm log message was written
+	bytes, err := ioutil.ReadFile(tmpf.Name())
+	if err != nil {
+		t.Errorf("error reading temp file[%s]: %v\n", tmpf.Name(), err)
+	}
+
+	logFileBytes := string(bytes)
+	if !strings.Contains(logFileBytes, logStr) {
+		t.Logf("logfile:\n%s", logFileBytes)
+		t.Errorf("%s not found in logfile %s\n", logStr, tmpf.Name())
+	}
+}
+
+func TestLogrusLogger(t *testing.T) {
+	SetupLogrus("debug")
+
+	Debug("Debug")
+	Infof("Info")
+	Warn("Warn")
+	Error("Error")
+
+	rus = nil
+}


### PR DESCRIPTION
Enables using [lytics/logrus](https://github.com/lytics/logrus)(forked from [Sirupsen/logrus](https://github.com/Sirupsen/logrus) as a log output formatter. `lytics/logrus` was modified to satisfy `lytics/metafora`'s [LogOutputter](https://github.com/lytics/metafora/blob/master/logger.go#L50) interface. The changes probably won't be useful to the main `logrus` userbase, so not attempting to get them merged.

This allows clean integration with Google Cloud Platforms [Logging service](https://cloud.google.com/logging/) format from [GKE](https://cloud.google.com/container-engine/) containers.