### PR TITLE
Extra Three characters make all the difference

### DIFF
--- a/log.go
+++ b/log.go
@@ -484,7 +484,6 @@ func DoLog(depth, logLvl int, msg string) {
 			"line": line,
 		})
 
-		msg = fmt.Sprintf("%s:%d %s", file, line, msg)
 		// Write logs using Logrus logger
 		logrusLvl := logrus.Level(logLvl) + 1
 		switch logrusLvl {

--- a/log.go
+++ b/log.go
@@ -479,7 +479,7 @@ func DoLog(depth, logLvl int, msg string) {
 			line = 0
 		}
 
-		entry := logrus.WithFields(logrus.Fields{
+		entry := rus.WithFields(logrus.Fields{
 			"file": file,
 			"line": line,
 		})


### PR DESCRIPTION
By invoking the log Entry from the logrus package, it skipped all of the
settings configured around the `rus` Logrus invocation variable. Thus writing
logs with default logrus settings.